### PR TITLE
Add RoboTwin evaluation (policy plugin + docs)

### DIFF
--- a/Evo_1/scripts/Evo1_server.py
+++ b/Evo_1/scripts/Evo1_server.py
@@ -197,7 +197,7 @@ def load_model_and_normalizer(ckpt_dir):
 
     config_dict["finetune_vlm"] = False
     config_dict["finetune_action_head"] = False
-    config_dict["num_inference_timesteps"] = 32
+    config_dict["num_inference_timesteps"] = 50
 
     from config import EvoConfig
     config = EvoConfig.from_dict(config_dict)
@@ -227,10 +227,12 @@ def decode_image_from_list(img_list):
 def infer_from_json_dict(data: dict, model, normalizer, arm_key, dataset_key):
     device = "cuda"
     model_dtype = next(model.parameters()).dtype
-    # arm_key = data["arm_key"]
-    # arm_key = "franka_joint_angle"
-    # dataset_key = data["dataset_key"] 
-    # dataset_key = "close_box_120_w_last"
+    # Prefer per-request arm_key/dataset_key from the client payload; fall back to the
+    # server startup defaults. Needed for multi-task benchmarks (RoboTwin sends
+    # arm_key=aloha_joint and a per-task dataset_key=robotwin_<task>, and the norm
+    # stats are keyed per task).
+    arm_key = data.get("arm_key", arm_key)
+    dataset_key = data.get("dataset_key", dataset_key)
 
   
     images = [decode_image_from_list(img) for img in data["image"]]
@@ -301,7 +303,7 @@ if __name__ == "__main__":
         print(f"EVO_1 server running at ws://0.0.0.0:{port}")
         async with websockets.serve(
             lambda ws: handle_request(ws, model, normalizer, arm_key, dataset_key),
-            "0.0.0.0", port, max_size=100_000_000
+            "0.0.0.0", port, max_size=100_000_000, ping_interval=None, ping_timeout=None
         ):
             await asyncio.Future()
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![🌍 Website](https://img.shields.io/badge/Github-Website-green)](https://mint-sjtu.github.io/Evo-1.io/)  
 
 ## 📰 News  
+- 🗓️ **2026-07-21** — Released RoboTwin evaluation (Evo-1 policy plugin + 50 bimanual tasks)
 - 🗓️ **2026-04-08** — Evo-1 is now fully integrated into the LeRobot framework!
 - 🗓️ **2026-04-08** — We released Evo-1 Docker support for Jetson (https://huggingface.co/datasets/MINT-SJTU/Evo-1_JetsonOrin).
 - 🗓️ **2026-02-20** — Evo-1 is accepted by CVPR 2026 🎉🎉
@@ -24,8 +25,8 @@
 - ✅ Add Evo-1 to the LeRobot framework 
     (check evo1-lerobot branch)
 - ✅ Release instructions for deploying Evo-1 on Jetson Orin (https://huggingface.co/datasets/MINT-SJTU/Evo-1_JetsonOrin)
+- ✅ Release RoboTwin evaluation script
 - ⬜ Release results of all 50 RoboTwin tasks
-- ⬜ Release RoboTwin evaluation script  
 
 
 ## ⚙️ Installation
@@ -192,6 +193,76 @@ cd LIBERO_evaluation
 python libero_client_4tasks.py
 ```
 <br>
+
+---
+
+### 🧪 RoboTwin Benchmark
+
+RoboTwin (50 bimanual manipulation tasks in SAPIEN) uses a **policy-plugin** architecture: start the Evo-1 server, drop the Evo-1 policy adapter into a RoboTwin checkout, and launch RoboTwin's evaluator as the client.
+
+#### 1️⃣ Prepare the environment for RoboTwin
+
+RoboTwin is **not** bundled in this repo. Clone and install it separately (SAPIEN + CuRobo are required):
+
+```bash
+conda create -n RoboTwin python=3.10 -y
+conda activate RoboTwin
+
+git clone https://github.com/TianxingChen/RoboTwin.git
+cd RoboTwin
+pip install -r script/requirements.txt
+pip install websockets
+
+# CuRobo is REQUIRED — expert solvability check and scene setup use its motion planner
+cd envs && git clone https://github.com/NVlabs/curobo.git
+cd curobo && python -m pip install -e . --no-build-isolation && cd ../..
+```
+> See the [RoboTwin README](https://github.com/TianxingChen/RoboTwin) for full setup (assets, SAPIEN, mplib).
+
+#### 2️⃣ Model Preparation
+
+##### 📥 2.1 Download Model Weight
+
+```bash
+hf download MINT-SJTU/Evo1_RoboTwin --local-dir /path/to/save/checkpoint/
+```
+
+##### ✏️ 2.2 Modify config
+
+1. Modify checkpoint dir: [Evo1_server.py](Evo_1/scripts/Evo1_server.py#L288)
+2. **`arm_key` / `dataset_key`: no server edit needed for RoboTwin.** The client sends them per request (`arm_key=aloha_joint`, per-task `dataset_key=robotwin_<task>`) and the server reads them from the payload. RoboTwin `norm_stats.json` is keyed **per task** (50 keys under `aloha_joint`), so a single fixed `dataset_key` would be wrong for 49/50 tasks — the per-request key is required.
+3. (Optional) Modify server port: [Evo1_server.py](Evo_1/scripts/Evo1_server.py#L291)
+
+##### 🔌 2.3 Install the Evo-1 policy plugin into RoboTwin
+
+```bash
+cp -r RoboTwin_evaluation/policy/Evo1  /path/to/RoboTwin/policy/Evo1
+```
+
+#### 3️⃣ Run RoboTwin Evaluation
+
+```bash
+# Terminal 1 — Evo-1 server (PYTHONPATH=. lets the server import scripts.* and config)
+conda activate Evo1
+cd Evo_1
+PYTHONPATH=. python scripts/Evo1_server.py
+```
+
+```bash
+# Terminal 2 — RoboTwin client, one task
+conda activate RoboTwin
+cd /path/to/RoboTwin/policy/Evo1
+
+# Usage: bash eval.sh <task_name> [task_config] [ckpt_setting] [seed] [gpu_id] [server_url] [horizon]
+bash eval.sh place_burger_fries demo_clean step_20000 0 0 ws://0.0.0.0:9000 37
+```
+
+> **⚠️ Evaluation recipe — three settings must be applied together (dropping any one roughly halves the success rate):**
+> 1. **`horizon=37`** — actions executed per inference call (the default in `eval.sh`; success rate rises with horizon and plateaus around 37).
+> 2. **`num_inference_timesteps=50`** in `Evo1_server.py` (not 32 — 32 causes action jitter).
+> 3. **Gaussian action smoothing, kernel=9** — hardcoded in `policy/Evo1/deploy_policy.py`.
+>
+> All three are already configured in this repo. Each task runs 100 episodes with expert solvability check; results are written under `RoboTwin/eval_result/`.
 
 ----
 

--- a/RoboTwin_evaluation/README.md
+++ b/RoboTwin_evaluation/README.md
@@ -1,0 +1,32 @@
+# RoboTwin Evaluation for Evo-1
+
+Full setup and run instructions live in the top-level
+[README → 🧪 RoboTwin Benchmark](../README.md#-robotwin-benchmark).
+
+This directory ships the Evo-1 **policy plugin** for RoboTwin:
+
+```
+policy/Evo1/
+  deploy_policy.py   # RoboTwin policy interface: obs -> server -> smoothed 14-D action chunk
+  deploy_policy.yml  # default config (horizon=37)
+  eval.sh            # single-task launcher
+```
+
+Install it into a RoboTwin checkout:
+
+```bash
+cp -r policy/Evo1  /path/to/RoboTwin/policy/Evo1
+```
+
+The Evo-1 server reads `arm_key` / `dataset_key` from each client request, so **no server-side
+edit is needed for RoboTwin** — the client sends `arm_key=aloha_joint` and the per-task
+`dataset_key=robotwin_<task>` (RoboTwin `norm_stats.json` is keyed per task, 50 keys under
+`aloha_joint`).
+
+## ⚠️ Evaluation recipe (all three matter — dropping any one roughly halves success rate)
+
+1. **`horizon=37`** — actions executed per inference call (default in `eval.sh` / `deploy_policy.yml`).
+2. **`num_inference_timesteps=50`** in `Evo_1/scripts/Evo1_server.py` (not 32; 32 causes action jitter).
+3. **Gaussian action smoothing, kernel=9** — hardcoded in `deploy_policy.py` `eval()`.
+
+Verified on `place_burger_fries` (2/2 success at horizon=37) with the RoboTwin multitask checkpoint.

--- a/RoboTwin_evaluation/policy/Evo1/__init__.py
+++ b/RoboTwin_evaluation/policy/Evo1/__init__.py
@@ -1,0 +1,1 @@
+from .deploy_policy import *

--- a/RoboTwin_evaluation/policy/Evo1/deploy_policy.py
+++ b/RoboTwin_evaluation/policy/Evo1/deploy_policy.py
@@ -1,0 +1,135 @@
+import asyncio
+import json
+import cv2
+import numpy as np
+import websockets
+
+
+def encode_image_array(img_rgb):
+    bgr = cv2.cvtColor(img_rgb, cv2.COLOR_RGB2BGR)
+    return bgr.astype(np.uint8).tolist()
+
+
+def encode_obs(observation):
+    head_img = observation["observation"]["head_camera"]["rgb"]
+    left_img = observation["observation"]["left_camera"]["rgb"]
+    right_img = observation["observation"]["right_camera"]["rgb"]
+    state = observation["joint_action"]["vector"].tolist()
+    return head_img, left_img, right_img, state
+
+
+def _gaussian_smooth(actions, kernel_size=9):
+    """Gaussian-weighted smoothing along the time axis (center weighted highest)."""
+    T, D = actions.shape
+    half = kernel_size // 2
+    sigma = half / 2.0
+    kernel = np.exp(-0.5 * (np.arange(kernel_size) - half) ** 2 / (sigma ** 2))
+    kernel /= kernel.sum()
+
+    smoothed = np.copy(actions)
+    for t in range(T):
+        start = max(0, t - half)
+        end = min(T, t + half + 1)
+        k_start = half - (t - start)
+        k_end = half + (end - t)
+        w = kernel[k_start:k_end]
+        w = w / w.sum()  # renormalize at boundaries
+        smoothed[t] = (actions[start:end] * w[:, None]).sum(axis=0)
+    return smoothed
+
+
+def smooth_actions(actions, kernel_size=9, smooth_type="gaussian"):
+    """Smooth an action chunk (T, D) along time. Gaussian is the validated recipe."""
+    T, D = actions.shape
+    if T <= kernel_size:
+        return actions
+    if smooth_type == "gaussian":
+        return _gaussian_smooth(actions, kernel_size)
+    # uniform moving-average fallback
+    smoothed = np.copy(actions)
+    half = kernel_size // 2
+    for t in range(T):
+        start = max(0, t - half)
+        end = min(T, t + half + 1)
+        smoothed[t] = actions[start:end].mean(axis=0)
+    return smoothed
+
+
+class Evo1Proxy:
+    def __init__(self, server_url, horizon, task_name):
+        self.server_url = server_url
+        self.horizon = horizon
+        self.task_name = task_name
+        self.dataset_key = f"robotwin_{task_name}"
+        self.arm_key = "aloha_joint"
+        self.ws = None
+        self.loop = asyncio.new_event_loop()
+
+    def connect(self):
+        async def _connect():
+            self.ws = await websockets.connect(
+                self.server_url,
+                ping_interval=None,
+                ping_timeout=None,
+                max_size=100_000_000,
+            )
+        self.loop.run_until_complete(_connect())
+
+    def infer(self, head_img, left_img, right_img, state, prompt):
+        payload = {
+            "image": [
+                encode_image_array(head_img),
+                encode_image_array(left_img),
+                encode_image_array(right_img),
+            ],
+            "state": state,
+            "prompt": prompt,
+            "image_mask": [1, 1, 1],
+            "action_mask": [1] * 14 + [0] * 10,
+            "dataset_key": self.dataset_key,
+            "arm_key": self.arm_key,
+        }
+
+        async def _infer():
+            await self.ws.send(json.dumps(payload))
+            result = await self.ws.recv()
+            return json.loads(result)
+
+        return self.loop.run_until_complete(_infer())
+
+    def close(self):
+        if self.ws:
+            self.loop.run_until_complete(self.ws.close())
+
+
+def get_model(usr_args):
+    server_url = usr_args.get("server_url", "ws://0.0.0.0:9000")
+    horizon = int(usr_args.get("horizon", 37))
+    task_name = usr_args["task_name"]
+
+    proxy = Evo1Proxy(server_url, horizon, task_name)
+    proxy.connect()
+    return proxy
+
+
+def eval(TASK_ENV, model, observation):
+    head_img, left_img, right_img, state = encode_obs(observation)
+    instruction = TASK_ENV.get_instruction()
+
+    actions_raw = model.infer(head_img, left_img, right_img, state, str(instruction))
+    actions = np.array(actions_raw)  # (50, 24) denormalized
+
+    # Smoothing hardcoded: gaussian kernel=9 (the validated RoboTwin recipe).
+    # Executing raw chunks jitters the arm and roughly halves success rate.
+    actions = smooth_actions(actions, kernel_size=9, smooth_type="gaussian")
+
+    for i in range(model.horizon):
+        action_14d = actions[i][:14]  # 7 left + 7 right joints
+        TASK_ENV.take_action(action_14d)
+        observation = TASK_ENV.get_obs()
+
+    return observation
+
+
+def reset_model(model):
+    pass

--- a/RoboTwin_evaluation/policy/Evo1/deploy_policy.yml
+++ b/RoboTwin_evaluation/policy/Evo1/deploy_policy.yml
@@ -1,0 +1,8 @@
+policy_name: Evo1
+task_name: null
+task_config: null
+ckpt_setting: null
+seed: null
+instruction_type: unseen
+server_url: "ws://0.0.0.0:9000"
+horizon: 37

--- a/RoboTwin_evaluation/policy/Evo1/eval.sh
+++ b/RoboTwin_evaluation/policy/Evo1/eval.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+policy_name=Evo1
+task_name=${1}
+task_config=${2:-demo_clean}
+ckpt_setting=${3:-step_20000}
+seed=${4:-0}
+gpu_id=${5:-0}
+server_url=${6:-ws://0.0.0.0:9000}
+horizon=${7:-37}
+
+export CUDA_VISIBLE_DEVICES=${gpu_id}
+echo -e "\033[33mgpu id (to use): ${gpu_id}\033[0m"
+
+cd ../..
+
+PYTHONWARNINGS=ignore::UserWarning PYTHONUNBUFFERED=1 \
+stdbuf -oL python -u script/eval_policy.py --config policy/$policy_name/deploy_policy.yml \
+    --overrides \
+    --task_name ${task_name} \
+    --task_config ${task_config} \
+    --ckpt_setting ${ckpt_setting} \
+    --seed ${seed} \
+    --policy_name ${policy_name} \
+    --server_url ${server_url} \
+    --horizon ${horizon}


### PR DESCRIPTION
- RoboTwin_evaluation/policy/Evo1: deploy_policy (gaussian k=9 smoothing, horizon 37), deploy_policy.yml, eval.sh
- Evo1_server.py: num_inference_timesteps 50; disable websocket keepalive (ping_interval/ping_timeout=None); read arm_key/dataset_key from client payload (RoboTwin norm_stats are keyed per task, 50 keys under aloha_joint)
- README: add RoboTwin Benchmark section; update roadmap + news

Verified end-to-end: place_burger_fries 2/2 success at horizon=37.